### PR TITLE
[SIK6-5] chore(format): add Formatter basic set up for Front and Back #5

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,15 +7,31 @@
       "extends": [
         "eslint:recommended",
         "plugin:@angular-eslint/recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
       ],
       "rules": {
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": ["error", {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_"
-        }],
-        "no-console": "warn"
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
+          }
+        ],
+        "no-console": "warn",
+
+        "@typescript-eslint/no-floating-promises": "off",
+        "@typescript-eslint/consistent-type-imports": "warn",
+        "@typescript-eslint/no-misused-promises": "off",
+
+        "eqeqeq": ["error", "smart"],
+        "curly": ["error", "all"],
+        "prefer-const": "error",
+        "no-return-await": "warn",
+
+        "@angular-eslint/no-empty-lifecycle-method": "warn",
+        "@angular-eslint/use-pipe-transform-interface": "warn"
       }
     },
     {

--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -1,34 +1,41 @@
 ---
-name: "Bug Report"
-about: "Report a bug to help us improve"
-title: "[Bug] "
+name: 'Bug Report'
+about: 'Report a bug to help us improve'
+title: '[Bug] '
 labels: []
 assignees: 0xm0-v1
 ---
 
 ## Related Work
+
 - Ticket: #<ticket_number>
 - User Story: #<user_story_number>
 
 ## Description
+
 **A clear and concise description of the problem:**
 
 ## Steps to Reproduce
+
 1. Go to '...'
 2. Click on '...'
 3. Scroll down to '...'
 4. See error
 
 ## Expected Behavior
+
 **What you expected to happen:**
 
 ## Actual Behavior
+
 **What actually happened:**
 
 ## Screenshots / Logs
+
 **If applicable, add screenshots or logs to help explain your problem:**
 
 ## Environment
+
 - **OS: [e.g. iOS, Windows]:**
 - **Browser/Version: [e.g. Chrome 100.0]:**
 - **App Version: [e.g. v1.2.3]:**
@@ -36,9 +43,10 @@ assignees: 0xm0-v1
 
 ---
 
-**Definition of Done (DoD)**  
-- [ ] Bug reproduced and documented  
-- [ ] Fix implemented and tested  
-- [ ] Tests passing (unit/integration)  
-- [ ] Reviewed and merged  
-- [ ] Verified in staging/production  
+**Definition of Done (DoD)**
+
+- [ ] Bug reproduced and documented
+- [ ] Fix implemented and tested
+- [ ] Tests passing (unit/integration)
+- [ ] Reviewed and merged
+- [ ] Verified in staging/production

--- a/.github/ISSUE_TEMPLATE/issue-ticket-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-ticket-template.md
@@ -1,7 +1,7 @@
 ---
-name: "Tracking Issue"
-about: "Use this template for tracking new features or organizational tasks"
-title: "[Ticket] "
+name: 'Tracking Issue'
+about: 'Use this template for tracking new features or organizational tasks'
+title: '[Ticket] '
 labels: []
 assignees: 0xm0-v1
 ---
@@ -9,45 +9,56 @@ assignees: 0xm0-v1
 ## [Ticket Title]
 
 ## Related User Story
+
 - #<user_story_number>
 
 ## 🔗 Blocked by
+
 - #<ticket_number>
 
 ### Priority
+
 - P0 / P1 / P2
 
 ### Description
-- **Ticket goal / purpose:**  
-- **Context or problem statement:** 
+
+- **Ticket goal / purpose:**
+- **Context or problem statement:**
 - **Points to cover (list items, e.g., volumes, constraints, assumptions…):**
-``` bash
+
+```bash
 - coverage here
-``` 
+```
 
 ### Deliverable
+
 - **Expected file / doc / output (e.g., `docs/.../needs.md`):**
-Clear linkage to child tickets:
+  Clear linkage to child tickets:
 - #
-- **Expected sections (e.g., *Introduction, Functional Needs, Constraints*):**   
+- **Expected sections (e.g., _Introduction, Functional Needs, Constraints_):**
 - **Format or size (e.g., 1 page, diagram, table, etc.):**
 
 ### Stakeholders
+
 - **Target roles (e.g., Product Manager, Tech Lead, QA…):**
 
 ### Timeline
+
 - **Milestone or due date (e.g., Day 0, Sprint 1, Release X):**
 
 ### References / Standards
-- **Based on any relevant guideline:**  
+
+- **Based on any relevant guideline:**
 - **Useful links (wiki, RFCs, related issues):**
 
 ### Out of Scope
+
 - **Explicitly list what is not part of this ticket:**
 
 ---
 
-**Definition of Done (DoD)**  
-- [ ] Deliverable created and stored in the right location  
-- [ ] Content covers all described points  
-- [ ] Content reviewed/validated by relevant stakeholders (Product / Tech / QA)  
+**Definition of Done (DoD)**
+
+- [ ] Deliverable created and stored in the right location
+- [ ] Content covers all described points
+- [ ] Content reviewed/validated by relevant stakeholders (Product / Tech / QA)

--- a/.github/ISSUE_TEMPLATE/user-story-template.md
+++ b/.github/ISSUE_TEMPLATE/user-story-template.md
@@ -1,42 +1,48 @@
 ---
-name: "User Story"
-about: "Template for capturing user needs and acceptance criteria"
-title: "[Story] "
+name: 'User Story'
+about: 'Template for capturing user needs and acceptance criteria'
+title: '[Story] '
 labels: [user-story]
 assignees: 0xm0-v1
 ---
 
 ## Associated Tickets
+
 - #<ticket_number>
 
 ## 🔗 Blocked by
+
 - #<ticket_number>
 
 ## User Story
-- As a **[type of user]**,  
-- I want **[some goal]**,  
+
+- As a **[type of user]**,
+- I want **[some goal]**,
 - So that **[some reason / value]**.
 
 ---
 
 ## Acceptance Criteria
+
 - **Given** [some context]  
   **When** [some action is taken]  
-  **Then** [expected outcome]  
+  **Then** [expected outcome]
 
-- **Additional acceptance criteria… ** 
+- **Additional acceptance criteria… **
 
 ---
 
 ## Notes / Details
-- **Business rules, constraints, dependencies:**  
-- **Links to designs, API docs, related issues:**  
+
+- **Business rules, constraints, dependencies:**
+- **Links to designs, API docs, related issues:**
 
 ---
 
 ## Definition of Done (DoD)
-- [ ] Story implemented and meets all acceptance criteria  
-- [ ] Unit/integration tests added and passing  
-- [ ] Code reviewed and merged  
-- [ ] Documentation updated (if needed)  
-- [ ] Deployed to staging and validated  
+
+- [ ] Story implemented and meets all acceptance criteria
+- [ ] Unit/integration tests added and passing
+- [ ] Code reviewed and merged
+- [ ] Documentation updated (if needed)
+- [ ] Deployed to staging and validated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,32 @@
 # Pull Request
 
 ## Related Issues
+
 - Closes #<ticket_number>
-- Relates to #<user_story_number> 
+- Relates to #<user_story_number>
 - Linked to ADR/Docs: <link if any>
 
 ## Summary
+
 **Briefly describe the purpose of this PR (1–3 sentences):**
 
 ## Type of Change
-- [ ]  Feature
-- [ ]  Bug fix
-- [ ]  Documentation
-- [ ]  Refactor / Chore
-- [ ]  Security
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Refactor / Chore
+- [ ] Security
 
 ## Testing
-- [ ]  Unit tests added/updated
-- [ ]  Integration tested locally
-- [ ]  No breaking changes
+
+- [ ] Unit tests added/updated
+- [ ] Integration tested locally
+- [ ] No breaking changes
 
 ## Checklist
-- [ ]  Code lints/formatting passed
-- [ ]  Tests run locally and pass
-- [ ]  Commits follow conventions
-- [ ]  Documentation updated (if needed)
+
+- [ ] Code lints/formatting passed
+- [ ] Tests run locally and pass
+- [ ] Commits follow conventions
+- [ ] Documentation updated (if needed)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,19 +1,29 @@
 #!/usr/bin/env sh
 . "$(git rev-parse --show-toplevel)/.husky/project-env"
 
-echo "🔎 Running linters..."
+echo "▶ Format FE (lint-staged)…"
+npx lint-staged
+FE_FORMAT_STATUS=$?
 
-# Backend (Go)
+echo "▶ Format Go (staged only, via gofumpt)…"
+GO_FILES=$(git diff --name-only --cached -- '*.go')
+if [ -n "$GO_FILES" ]; then
+  echo "$GO_FILES" | xargs gofumpt -w
+  echo "$GO_FILES" | xargs git add
+fi
+GO_FORMAT_STATUS=$?
+
+echo "▶ Lints Go…"
 make lint
 BACKEND_STATUS=$?
 
-# Frontend (Angular/TS)
+echo "▶ Lints FE…"
 npm run lint
 FRONTEND_STATUS=$?
 
-if [ $BACKEND_STATUS -ne 0 ] || [ $FRONTEND_STATUS -ne 0 ]; then
-  echo "❌ Linting failed. Fix errors before committing."
+if [ $FE_FORMAT_STATUS -ne 0 ] || [ $GO_FORMAT_STATUS -ne 0 ] || [ $BACKEND_STATUS -ne 0 ] || [ $FRONTEND_STATUS -ne 0 ]; then
+  echo "❌ Pre-commit checks failed."
   exit 1
 fi
 
-echo "✅ All lint checks passed!"
+echo "✅ Pre-commit checks passed."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,29 +1,37 @@
 #!/usr/bin/env sh
 . "$(git rev-parse --show-toplevel)/.husky/project-env"
 
-echo "▶ Format FE (lint-staged)…"
-npx lint-staged
-FE_FORMAT_STATUS=$?
+echo "▶ Running formatters (lint-staged for FE)…"
+npx lint-staged || {
+  echo "❌ lint-staged failed. Fix formatting before committing."
+  exit 1
+}
 
-echo "▶ Format Go (staged only, via gofumpt)…"
+echo "▶ Running gofumpt on staged Go files…"
 GO_FILES=$(git diff --name-only --cached -- '*.go')
 if [ -n "$GO_FILES" ]; then
-  echo "$GO_FILES" | xargs gofumpt -w
+  command -v gofumpt >/dev/null 2>&1 || {
+    echo "⚠️ gofumpt not found. Install it with: go install mvdan.cc/gofumpt@latest"
+    exit 1
+  }
+  echo "$GO_FILES" | xargs gofumpt -w || {
+    echo "❌ gofumpt failed."
+    exit 1
+  }
+  # re-add formatted files
   echo "$GO_FILES" | xargs git add
 fi
-GO_FORMAT_STATUS=$?
 
-echo "▶ Lints Go…"
-make lint
-BACKEND_STATUS=$?
-
-echo "▶ Lints FE…"
-npm run lint
-FRONTEND_STATUS=$?
-
-if [ $FE_FORMAT_STATUS -ne 0 ] || [ $GO_FORMAT_STATUS -ne 0 ] || [ $BACKEND_STATUS -ne 0 ] || [ $FRONTEND_STATUS -ne 0 ]; then
-  echo "❌ Pre-commit checks failed."
+echo "▶ Running Go lints…"
+make lint || {
+  echo "❌ Go linting failed."
   exit 1
-fi
+}
+
+echo "▶ Running ESLint…"
+npm run lint || {
+  echo "❌ ESLint failed."
+  exit 1
+}
 
 echo "✅ Pre-commit checks passed."

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 node_modules/
-dist/
-coverage/
+**/dist/
+**/coverage/
 .tmp/
 backend/
 .angular/
+*.min.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+.tmp/
+backend/
+.angular/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "*.html",
+      "options": { "parser": "angular" }
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,16 @@ This document defines the contribution rules for the **sik6** project.
 All team members are expected to follow these conventions to ensure consistency and maintainability.
 
 ## Standards
-- [Commits](./docs/conventions/commits.md)  
-- [Labels](./docs/conventions/labels.md)  
-- [Images](./docs/conventions/images.md)  
-- [Linting](./docs/conventions/lint.md) 
+
+- [Commits](./docs/conventions/commits.md)
+- [Labels](./docs/conventions/labels.md)
+- [Images](./docs/conventions/images.md)
+- [Linting](./docs/conventions/lint.md)
+- [Formatting](./docs/conventions/format.md)
 
 ## Workflow
-1. Create a branch from `main`.  
-2. Implement and test your changes locally.  
-3. Commit your changes — pre-commit hooks will automatically enforce linting and conventions.  
-4. Open a Pull Request for review and approval before merging.  
+
+1. Create a branch from `main`.
+2. Implement and test your changes locally.
+3. Commit your changes — pre-commit hooks will automatically enforce linting / formatting and conventions.
+4. Open a Pull Request for review and approval before merging.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # Go project Makefile
 
-.PHONY: lint
+.PHONY: lint format
 
 # Run golangci-lint on the whole project
 lint:
 	golangci-lint run ./...
+
+# Format Go
+format:
+	gofumpt -w .

--- a/README.md
+++ b/README.md
@@ -17,24 +17,31 @@
 </h4>
 
 # 📖 Table of Contents
+
 1. [Quick Start](#-quick-start)
 2. [Contributing](#-contributing)
 3. [Useful Links](#-useful-links)
 
 ## ⚡ Quick Start
-### Installation 
+
+### Installation
+
 > Make sure you have the following locally 👇
+
 - [Go 1.25](https://go.dev/dl/)
 - [Angular 20](https://angular.dev/installation)
 - [PostgreSQL 17.6](https://www.postgresql.org/download/)
 
 > And now you can get the Repository 👇
+
 ```bash
 git clone https://github.com/0xm0-v1/sik6
 ```
 
 ## 🔗 Useful Links
-- 🎨 [Designs (Figma)](https://www.figma.com/files/team/1304730716403620532/project/127010998/sik6?fuid=1254181321735275578) – UI/UX mockups and design system 
+
+- 🎨 [Designs (Figma)](https://www.figma.com/files/team/1304730716403620532/project/127010998/sik6?fuid=1254181321735275578) – UI/UX mockups and design system
 
 ## 🤝 Contributing
-*Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request.*
+
+_Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request._

--- a/docs/conventions/commits.md
+++ b/docs/conventions/commits.md
@@ -1,99 +1,108 @@
-# Commit Conventions 
+# Commit Conventions
+
 This document defines the commit conventions to follow for the **sik6** project.  
 The goal is to ensure **clear traceability**, **consistency** in Git history, and to **enable automation** (changelog, release, CI/CD).
 
 ## Format
-Each commit must follow this structure:\
-`
-[SIK6-<num>] <type>(<scope>): <short, imperative message> #<ref>
-`
 
+Each commit must follow this structure:\
+`[SIK6-<num>] <type>(<scope>): <short, imperative message> #<ref>`
 
 ### Details:
+
 - **[SIK6-<num>]**: project ticket ID (`SIK6` is constant, `<num>` is the ticket number).
 - **type**: the nature of the change.
-- **scope** *(optional)*: the module, file, or component affected.
+- **scope** _(optional)_: the module, file, or component affected.
 - **message**: a short description written in the imperative mood.
 - **ref**: short ID reference of the issue.
 
 ## Rules
 
-1. **Ticket ID required**  
-   - Always use the **Ticket number** (`SIK6-123`), **never a User Story ID**.  
+1. **Ticket ID required**
+   - Always use the **Ticket number** (`SIK6-123`), **never a User Story ID**.
    - Commits trace back to a **Ticket**, and the Ticket itself is linked to its User Story.
 
-2. **Conventional commit types**  
-   - `feat`: a new feature  
-   - `fix`: a bug fix  
-   - `docs`: documentation only changes  
-   - `style`: formatting, missing semi colons, etc.; no code change  
-   - `refactor`: code change that neither fixes a bug nor adds a feature  
-   - `perf`: performance improvements  
-   - `test`: adding or updating tests  
-   - `chore`: build process or auxiliary tool changes  
-   - `design`: design related 
+2. **Conventional commit types**
+   - `feat`: a new feature
+   - `fix`: a bug fix
+   - `docs`: documentation only changes
+   - `style`: formatting, missing semi colons, etc.; no code change
+   - `refactor`: code change that neither fixes a bug nor adds a feature
+   - `perf`: performance improvements
+   - `test`: adding or updating tests
+   - `chore`: build process or auxiliary tool changes
+   - `design`: design related
 
-3. **Example of Scope**  
+3. **Example of Scope**
    #### Backend
-- `api`: REST/GraphQL endpoints, controllers  
-- `auth`: authentication, authorization, session handling  
-- `db`: database models, schema, migrations  
-- `core`: core domain logic, services, business rules  
-- `cache`: caching layer (Redis, in-memory, etc.)  
-- `config`: configuration files, environment setup  
+
+- `api`: REST/GraphQL endpoints, controllers
+- `auth`: authentication, authorization, session handling
+- `db`: database models, schema, migrations
+- `core`: core domain logic, services, business rules
+- `cache`: caching layer (Redis, in-memory, etc.)
+- `config`: configuration files, environment setup
 
 #### Frontend
-- `ui`: user interface, layout, components  
-- `ux`: user experience, interactions, accessibility  
-- `forms`: form handling, validation  
-- `routing`: client-side routing, navigation  
+
+- `ui`: user interface, layout, components
+- `ux`: user experience, interactions, accessibility
+- `forms`: form handling, validation
+- `routing`: client-side routing, navigation
 
 #### Infrastructure & Ops
-- `ci`: CI/CD pipelines (GitHub Actions, GitLab CI, etc.)  
-- `build`: build system, bundlers, compilers  
-- `deps`: dependencies, libraries, package updates  
-- `docker`: Dockerfiles, containerization  
-- `infra`: infrastructure as code, deployment scripts  
+
+- `ci`: CI/CD pipelines (GitHub Actions, GitLab CI, etc.)
+- `build`: build system, bundlers, compilers
+- `deps`: dependencies, libraries, package updates
+- `docker`: Dockerfiles, containerization
+- `infra`: infrastructure as code, deployment scripts
 
 #### Quality & Testing
-- `test`: unit/integration tests  
-- `e2e`: end-to-end tests  
-- `lint`: linting, formatting, code quality  
+
+- `test`: unit/integration tests
+- `e2e`: end-to-end tests
+- `lint`: linting, formatting, code quality
 
 #### Documentation
-- `docs`: documentation, README, ADRs  
-- `changelog`: versioning, release notes  
+
+- `docs`: documentation, README, ADRs
+- `changelog`: versioning, release notes
 
 #### Security
-- `sec`: security fixes, vulnerabilities, patches  
 
-4. **Message**  
-   - Keep it short and descriptive.  
-   - Use the imperative mood: *"add"*, *"fix"*, *"update"* instead of *"added"*, *"fixed"*, *"updated"*.
+- `sec`: security fixes, vulnerabilities, patches
+
+4. **Message**
+   - Keep it short and descriptive.
+   - Use the imperative mood: _"add"_, _"fix"_, _"update"_ instead of _"added"_, _"fixed"_, _"updated"_.
 
 ## Hooks Enforcement
 
 To ensure commit conventions are respected consistently, Git hooks are configured with **Husky**.
 
 ### Prepare-commit-msg
-- Automatically injects the correct **ticket prefix** (`[SIK6-<num>]`) into the commit message template.  
-- This ensures contributors don’t forget to include the ticket ID.  
+
+- Automatically injects the correct **ticket prefix** (`[SIK6-<num>]`) into the commit message template.
+- This ensures contributors don’t forget to include the ticket ID.
 - Developers can then focus on writing the commit `type(scope): message #ref`.
 
 ### Commit-msg
-- Validates the final commit message format against the defined conventions.  
-- If the message does not match the required pattern, the commit is **blocked** until corrected.  
+
+- Validates the final commit message format against the defined conventions.
+- If the message does not match the required pattern, the commit is **blocked** until corrected.
 - This guarantees that all commits are tied to a valid ticket and follow the structure:
 
 ### Usage
+
 ```bash
 git commit
 ```
 
 ## Why this matters
 
-- Ensures every commit is tied to a **Ticket**.  
-- Tickets are then connected to **User Stories**, **PRs**, and **Issues**, providing full traceability.  
+- Ensures every commit is tied to a **Ticket**.
+- Tickets are then connected to **User Stories**, **PRs**, and **Issues**, providing full traceability.
 - Keeps commit history clean and consistent.
 
 _This commits system ensures every commit is tied to a **Ticket** and are then connected to **User Stories**, **PRs**, and **Issues**, providing full traceability, making commit history clean and consistent._

--- a/docs/conventions/format.md
+++ b/docs/conventions/format.md
@@ -1,0 +1,34 @@
+# Code Formatting Conventions
+
+The **sik6** project enforces automated formatting to keep the codebase consistent and easy to read.
+
+## Backend (Go)
+
+- **Tool**: [gofumpt](https://github.com/mvdan/gofumpt), a stricter version of `gofmt`.
+- **Manual command**:
+
+```bash
+  make format
+```
+
+- **Git hook**: staged `.go` files are automatically formatted on commit.
+
+## Frontend (Angular / TypeScript / HTML)
+
+- **Tool**: [Prettier](https://prettier.io/) with Angular-friendly settings:
+  - `singleQuote: true` (TypeScript → single quotes),
+  - `parser: angular` (for HTML templates).
+- **Manual commands:**
+
+```bash
+npm run format       # format all frontend files
+npm run format:check # verify formatting without writing
+```
+
+- **Git hook**: staged frontend files (`.ts`, `.html`, `.scss`, `.css`, `.json`, `.md`) are automatically formatted using [lint-staged](https://github.com/lint-staged/lint-staged).
+
+## Lint vs Format
+
+- **Prettier** → handles **style** (indentation, quotes, spacing, etc.).
+- **ESLint** → handles **quality** (unused variables, `console.log`, Angular/TS rules).
+  - All style-related rules are disabled via `eslint-config-prettier`.

--- a/docs/conventions/images.md
+++ b/docs/conventions/images.md
@@ -3,16 +3,15 @@
 This guide defines how to use images in our web project.  
 It covers formats, sizes, and usage rules to ensure **performance, quality, and compatibility**.
 
-
 ## Image Formats
 
-| Format  | When to Use | Notes |
-|---------|------------|-------|
-| **SVG** | Logos, icons, simple graphics | Vector, scalable, lightweight. Preferred whenever possible. |
-| **WebP** | General-purpose images (UI, content, backgrounds) | Best compromise quality/size. Supported by all modern browsers. |
-| **AVIF** | Large media, photos, hero images | Smaller than WebP, excellent quality, but slower encoding. Fallback needed. |
-| **PNG** | When transparency is required **and** SVG is not possible | Lossless, heavier. Use only if WebP/AVIF not viable. |
-| **JPG** | Photos when legacy support is required | Use progressive compression. Deprecated in most new use cases. |
+| Format   | When to Use                                               | Notes                                                                       |
+| -------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **SVG**  | Logos, icons, simple graphics                             | Vector, scalable, lightweight. Preferred whenever possible.                 |
+| **WebP** | General-purpose images (UI, content, backgrounds)         | Best compromise quality/size. Supported by all modern browsers.             |
+| **AVIF** | Large media, photos, hero images                          | Smaller than WebP, excellent quality, but slower encoding. Fallback needed. |
+| **PNG**  | When transparency is required **and** SVG is not possible | Lossless, heavier. Use only if WebP/AVIF not viable.                        |
+| **JPG**  | Photos when legacy support is required                    | Use progressive compression. Deprecated in most new use cases.              |
 
 > **Default format: WebP**, with fallback to PNG/JPG if legacy support is critical.
 
@@ -21,10 +20,10 @@ It covers formats, sizes, and usage rules to ensure **performance, quality, and 
 Always provide multiple resolutions and let the browser pick:
 
 ```html
-<img 
-  src="image-800.webp" 
-  srcset="image-400.webp 400w, image-800.webp 800w, image-1600.webp 1600w" 
-  sizes="(max-width: 600px) 100vw, 600px" 
+<img
+  src="image-800.webp"
+  srcset="image-400.webp 400w, image-800.webp 800w, image-1600.webp 1600w"
+  sizes="(max-width: 600px) 100vw, 600px"
   alt="Description"
 />
 ```
@@ -35,18 +34,18 @@ Always provide multiple resolutions and let the browser pick:
 
 ## Special Cases & Rules of Thumb
 
-| Category      | Specification / Rule | Notes |
-|---------------|----------------------|-------|
-| **Favicons**  | Multi-size `.ico` or PNGs | Sizes: 16, 32, 48, 64 px |
-| **PWA / App** | Icons: 512×512, 192×192, 180×180, 256×256 | Use PNG or WebP |
-| **Open Graph** | Facebook/LinkedIn → 1200×630 px (1.91:1) | Must be rectangular |
-| **Open Graph** | Twitter/X → 1200×600 px (2:1) | Do not stretch square logos |
-| **Logos**     | Use **SVG** whenever possible | Scalable, minimal |
-| **Bitmap**    | Default: **WebP** | Best balance quality/performance |
-| **Fallbacks** | PNG/JPG only if WebP/AVIF not supported | Avoid as primary format |
-| **Optimization** | Always compress images | Tools: ImageOptim, Squoosh, Sharp |
-| **Assets**    | Do **not** upload raw design exports | Avoid uncompressed PNGs |
-| **Hero images** | Prefer WebP/AVIF with `srcset` | Enable responsive loading |
-| **Accessibility** | Always include **meaningful alt text** | SEO + screen readers |
+| Category          | Specification / Rule                      | Notes                             |
+| ----------------- | ----------------------------------------- | --------------------------------- |
+| **Favicons**      | Multi-size `.ico` or PNGs                 | Sizes: 16, 32, 48, 64 px          |
+| **PWA / App**     | Icons: 512×512, 192×192, 180×180, 256×256 | Use PNG or WebP                   |
+| **Open Graph**    | Facebook/LinkedIn → 1200×630 px (1.91:1)  | Must be rectangular               |
+| **Open Graph**    | Twitter/X → 1200×600 px (2:1)             | Do not stretch square logos       |
+| **Logos**         | Use **SVG** whenever possible             | Scalable, minimal                 |
+| **Bitmap**        | Default: **WebP**                         | Best balance quality/performance  |
+| **Fallbacks**     | PNG/JPG only if WebP/AVIF not supported   | Avoid as primary format           |
+| **Optimization**  | Always compress images                    | Tools: ImageOptim, Squoosh, Sharp |
+| **Assets**        | Do **not** upload raw design exports      | Avoid uncompressed PNGs           |
+| **Hero images**   | Prefer WebP/AVIF with `srcset`            | Enable responsive loading         |
+| **Accessibility** | Always include **meaningful alt text**    | SEO + screen readers              |
 
 _This system ensures that images are lightweight, responsive, and accessible, reducing load times and improving the overall user experience while maintaining compatibility across modern browsers._

--- a/docs/conventions/labels.md
+++ b/docs/conventions/labels.md
@@ -4,48 +4,59 @@ This project uses a standardized set of **labels** to organize, prioritize, and 
 Each label has a clear purpose to ensure consistent communication across contributors.
 
 ## bug
+
 **Description:** Something isn’t working as expected.  
 **Use when:** Reporting defects, malfunctions, or unintended behaviors in the system.
 
 ## design
+
 **Description:** Visual and UX/UI work such as mockups, prototypes, or style guides.
 **Use when:** A task involves product look, feel, or user experience before/alongside development.
 
 ## documentation
+
 **Description:** Improvements or additions to documentation.  
 **Use when:** Updating guides, fixing typos, or creating new documentation.
 
 ## enhancement
+
 **Description:** New feature or request.  
 **Use when:** Suggesting improvements, optimizations, or additional functionality.
 
 ## priority: high (P0)
+
 **Description:** To be treated immediately.  
 **Use when:** Critical issues that block progress or severely impact users.
 
 ## priority: medium (P1)
+
 **Description:** Important but not blocking.  
 **Use when:** Issues that should be addressed soon but are not emergencies.
 
 ## priority: low (P2)
+
 **Description:** Nice-to-have, low urgency.  
 **Use when:** Non-blocking improvements, optimizations, or ideas.
 
 ## question
+
 **Description:** Clarification or discussion needed.  
 **Use when:** Asking questions, requesting feedback, or exploring ideas.
 
 ## task
+
 **Description:** Organizational or technical work.  
 **Use when:** Handling chores such as refactoring, CI/CD setup, or configuration.
 
 ## user-story
+
 **Description:** Functional story describing a user need.  
 **Use when:** Writing issues from the perspective of the end-user.
 
 ### Labeling Rules
-- Every issue **must have at least one type label** (`bug`, `enhancement`, `task`, etc.).  
-- Add a **priority label** (`priority: high`, `priority: medium`, `priority: low`) if applicable.  
-- Combine with `question` or `user-story` when additional context is required.  
+
+- Every issue **must have at least one type label** (`bug`, `enhancement`, `task`, etc.).
+- Add a **priority label** (`priority: high`, `priority: medium`, `priority: low`) if applicable.
+- Combine with `question` or `user-story` when additional context is required.
 
 _This labeling system ensures that **Issues** are consistently categorized and prioritized, making collaboration clearer and more efficient._

--- a/docs/conventions/lint.md
+++ b/docs/conventions/lint.md
@@ -1,54 +1,65 @@
 # Linting Conventions – sik6
 
 This document defines the linting rules applied in the **sik6** project.  
-It covers both the **backend (Go)** and the **frontend (Angular/TypeScript)** stacks.  
+It covers both the **backend (Go)** and the **frontend (Angular/TypeScript)** stacks.
 
-Linting ensures **code quality**, **consistency**, and helps **catch bugs early**.  
+Linting ensures **code quality**, **consistency**, and helps **catch bugs early**.
 
 ## Backend (Go)
 
 ### Tool
+
 - [golangci-lint](https://golangci-lint.run/) — industry-standard meta-linter for Go.
 
 ### Configuration
+
 - File: `.golangci.yml` (root of the repo).
 - Reference: `.golangci.reference.yml` (documented configuration for team).
 
 ### Enabled Linters
-- **govet**: detects misuses (printf formatting, struct alignment, etc.).  
-- **staticcheck**: advanced static analysis, best practices, bug prevention.  
+
+- **govet**: detects misuses (printf formatting, struct alignment, etc.).
+- **staticcheck**: advanced static analysis, best practices, bug prevention.
 - **unused**: finds unused variables, functions, imports.
 
 ### Exclusions
+
 - Skip directories: `vendor/`, `node_modules/`, `dist/`, `tmp/`.
 
 ### Usage
+
 ```bash
 make lint
 ```
+
 - Runs `golangci-lint run ./...` on the whole codebase.
 - Test files (`*_test.go`) are also included in linting.
 
 ## Frontend (Angular/TypeScript)
 
 ### Tool
+
 - [ESLint](https://eslint.org/) with [@angular-eslint](https://github.com/angular-eslint/angular-eslint)
 
 ### Configuration
+
 - File: `.eslintrc.json` (project root or `frontend/` when created).
 - Reference: `.eslintrc.reference.js` (documented configuration for team).
 - Ignore file: `.eslintignore`.
 
 ### Enabled Rules
+
 - Base: `eslint:recommended` + `plugin:@angular-eslint/recommended`.
 - Custom additions:
-    - `no-unused-vars: error` — unused variables are not allowed.
-    - `no-console: warn` — discourage leaving `console.log` in commits.
+  - `no-unused-vars: error` — unused variables are not allowed.
+  - `no-console: warn` — discourage leaving `console.log` in commits.
 
 ### Exclusions
+
 - Ignored paths: `node_modules/`, `dist/`, `coverage/`, `.tmp/`.
 
-### Usage 
+### Usage
+
 ```bash
 + npm run lint
 ```
@@ -56,13 +67,13 @@ make lint
 ```bash
 npm run lint:fix
 ```
+
 - Runs ESLint on all `.ts` files (and Angular templates).
 
 ## Pre-commit Hooks
-- Husky automatically runs both linters before commits:
-    - `make lint` (Go)
-    - `npm run lint` (Angular/TypeScript)
-> If linting fails, the commit is blocked until issues are resolved.
+
+- Husky automatically runs both linters before commits: - `make lint` (Go) - `npm run lint` (Angular/TypeScript)
+  > If linting fails, the commit is blocked until issues are resolved.
 
 ---
 
@@ -81,7 +92,7 @@ npm run lint:fix
   - `.eslintignore` excludes `node_modules/`, `dist/`, `coverage/`, `.tmp/`, and `backend/`.
 
 ### Note
-- Formatting (Prettier, gofmt, etc.) is handled in a **separate formatter setup ticket**.
+
 - This document will be updated as more rules are introduced over time.
 
 _This linting system ensures that all code remain consistent, maintainable and aligned, while providing immediate feedback to developers through automated checks & fix._

--- a/frontend/hello.ts
+++ b/frontend/hello.ts
@@ -1,5 +1,0 @@
-// Testing ESLint
-
-const sik6 = "Hello sik6!";
-
-console.log(sik6)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "eslint": "^8.57.1",
+        "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
+        "lint-staged": "16.1.6",
+        "prettier": "3.6.2",
         "typescript": "^5.9.2"
       }
     },
@@ -568,6 +571,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.0.tgz",
+      "integrity": "sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -678,6 +697,39 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.0.tgz",
+      "integrity": "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -697,6 +749,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -756,6 +825,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -826,6 +915,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -963,6 +1068,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1095,6 +1207,19 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1270,6 +1395,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1368,6 +1509,78 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.6.tgz",
+      "integrity": "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.0",
+        "commander": "^14.0.0",
+        "debug": "^4.4.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^9.0.3",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^1.0.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
+      "integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1390,6 +1603,55 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1415,6 +1677,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -1438,6 +1713,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nano-spawn": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
+      "integrity": "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1453,6 +1741,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1561,6 +1865,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1569,6 +1886,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -1612,6 +1945,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1622,6 +1972,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -1698,6 +2055,105 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi": {
@@ -1848,12 +2304,103 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,23 @@
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
+    "lint-staged": "16.1.6",
+    "prettier": "3.6.2",
     "typescript": "^5.9.2"
   },
   "scripts": {
     "prepare": "husky",
     "lint": "eslint . --ext .ts,.html --no-error-on-unmatched-pattern",
-    "lint:fix": "eslint . --ext .ts,.html --fix"
+    "lint:fix": "eslint . --ext .ts,.html --fix",
+    "format": "npm run format:fe",
+    "format:fe": "prettier \"**/*.{ts,html,scss,css,json,md}\" --write --ignore-unknown",
+    "format:check": "prettier \"**/*.{ts,html,scss,css,json,md}\" --check --ignore-unknown"
+  },
+  "lint-staged": {
+    "*.{ts,html,scss,css,json,md}": [
+      "prettier --write --ignore-unknown"
+    ]
   }
 }


### PR DESCRIPTION
# Pull Request

## Related Issues
- Closes #2  
- Relates to #2 
- Linked to ADR/Docs: [docs/conventions/format.md](docs/conventions/format.md)

## Summary
This PR introduces automated code formatting for both the Go backend and Angular frontend.  
It configures **gofumpt** for Go and **Prettier + lint-staged** for the frontend.  
It also adds dedicated documentation under `docs/conventions/format.md` and updates `CONTRIBUTING.md` with a reference.

## Type of Change
- [x] Documentation  
- [x] Refactor / Chore  

## Testing
- [x] No breaking changes  

## Checklist
- [x] Code lints/formatting passed  
- [x] Tests run locally and pass (manual verification of hooks + formatting)  
- [x] Commits follow conventions (`[SIK6-XXX] docs(conventions): add formatting guidelines`)  
- [x] Documentation updated (`docs/conventions/format.md` + `CONTRIBUTING.md`)  
